### PR TITLE
Scan할 각도 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+src

--- a/avoider.py
+++ b/avoider.py
@@ -1,0 +1,44 @@
+#!/home/pi/.pyenv/versions/rospy3/bin/python
+import rospy
+from geometry_msgs.msg import Twist
+from sensor_msgs.msg import LaserScan
+
+
+class SelfDrive:
+    def __init__(self, publisher):
+        self.publisher = publisher
+        self.count = 0
+
+    def lds_callback(self, scan):
+        right_range, left_range = 0, 0
+        turtle_vel = Twist()
+        for i in range(40):
+            range_per_angle = scan.ranges[i]
+            right_range += range_per_angle
+            range_per_angle = scan.ranges[320+i]
+            left_range += range_per_angle
+        right_range = right_range / 40
+        left_range = left_range / 40
+        if right_range < 0.25 or left_range < 0.25:
+            if right_range < left_range:
+                turtle_vel.linear.x = 0.0
+                turtle_vel.angular.z = -1.2
+            else:
+                turtle_vel.linear.x = 0.0
+                turtle_vel.angular.z = 1.2
+        else:
+            turtle_vel.linear.x = 0.18
+            turtle_vel.angular.z = 0.0
+        self.publisher.publish(turtle_vel)
+
+def main():
+    rospy.init_node('self_drive')
+    publisher = rospy.Publisher('cmd_vel', Twist, queue_size=1)
+    driver = SelfDrive(publisher)
+    subscriber = rospy.Subscriber('scan', LaserScan, lambda scan: driver.lds_callback(scan))
+    rospy.spin()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/pre_evaluation.py
+++ b/pre_evaluation.py
@@ -1,0 +1,32 @@
+#!/home/pi/.pyenv/versions/rospy3/bin/python
+import rospy
+from geometry_msgs.msg import Twist
+from sensor_msgs.msg import LaserScan
+
+
+class SelfDrive:
+    def __init__(self, publisher):
+        self.publisher = publisher
+        self.count = 0
+
+    def lds_callback(self, scan):
+        turtle_vel = Twist()
+        if scan.ranges[0] < 0.25:
+            turtle_vel.linear.x = 0.0
+            turtle_vel.angular.z = 0.0
+        else:
+            turtle_vel.linear.x = 0.18
+            turtle_vel.angular.z = 0.0
+        self.publisher.publish(turtle_vel)
+
+def main():
+    rospy.init_node('self_drive')
+    publisher = rospy.Publisher('cmd_vel', Twist, queue_size=1)
+    driver = SelfDrive(publisher)
+    subscriber = rospy.Subscriber('scan', LaserScan, lambda scan: driver.lds_callback(scan))
+    rospy.spin()
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
### 장애물 회피를 위한 scan 각도 변경
- 기존 : scan,ranges[0]을 사용하여 로봇의 전면의 LiDAR값 사용함.
- 변경 후 : 전면에서만 라이더값을 사용했던 것을 왼쪽장애물은 0부터 40 사이의 라이더의 평균값을 사용해 인식하고, 오른쪽 장애물은320부터 360사이의 라이더의 평균값을 사용해서 인식함. 
25cm이내에 0도 부터 40도 사이의 장애물이 인식이 되면 시계방향으로 회전하고, 320도 부터 360도 사이의 장애물이 인식이 되면 시계반대방향으로 회전한다.
그리고 25cm이내에 장애물이 인식 되지 않으면 18m/s로 직진하도록 코딩함.




