### PR TITLE
Wall follwer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 src
+HW-robot

--- a/outside.py
+++ b/outside.py
@@ -1,0 +1,60 @@
+#!/home/pi/.pyenv/versions/rospy3/bin/python
+import rospy
+from geometry_msgs.msg import Twist
+from sensor_msgs.msg import LaserScan
+
+
+class SelfDrive:
+    def __init__(self, publisher):
+        self.publisher = publisher
+        self.count = 0
+
+    def lds_callback(self, scan):
+        right_range, left_range = 0, 0
+        turtle_vel = Twist()
+        for i in range(40):
+            range_per_angle = scan.ranges[i]
+            right_range += range_per_angle
+            range_per_angle = scan.ranges[320+i]
+            left_range += range_per_angle
+        right_range = right_range / 40
+        left_range = left_range / 40
+        if right_range < 0.25 or left_range < 0.25:
+            if right_range < left_range:
+                turtle_vel.linear.x = 0.0
+                turtle_vel.angular.z = -1.2
+            else:
+                turtle_vel.linear.x = 0.0
+                turtle_vel.angular.z = 1.2
+        else:
+            if (scan.ranges[90] < 0.25 or scan.ranges[80] < 0.25) and (scan.ranges[270] > 0.25 or scan.ranges[280] > 0.25):
+                turtle_vel.linear.x = 0.18
+                turtle_vel.angular.z = 0.0
+            elif (scan.ranges[90] > 0.25 or scan.ranges[80] > 0.25) and (scan.ranges[270] > 0.25 or scan.ranges[280] > 0.25):
+                turtle_vel.linear.x = 0.18
+                turtle_vel.angular.z = 1.0
+                if scan.ranges[110] > 0.25:
+                    turtle_vel.linear.x = 0.18
+                    turtle_vel.angular.z = -0.1
+                elif scan.ranges[290]>0.25:
+                    turtle_vel.linear.x = 0.18
+                    turtle_vel.angular.z = 0.1
+            elif (scan.ranges[90] > 0.25 or scan.ranges[80] > 0.25) and (scan.ranges[270] < 0.25 or scan.ranges[280] < 0.25):
+                turtle_vel.linear.x = 0.18
+                turtle_vel.angular.z = 0.0
+            else:
+                turtle_vel.linear.x = 0.18
+                turtle_vel.angular.z = 0.0
+        self.publisher.publish(turtle_vel)
+
+
+def main():
+    rospy.init_node('self_drive')
+    publisher = rospy.Publisher('cmd_vel', Twist, queue_size=1)
+    driver = SelfDrive(publisher)
+    subscriber = rospy.Subscriber('scan', LaserScan, lambda scan: driver.lds_callback(scan))
+    rospy.spin()
+
+
+if __name__ == "__main__":
+    main()

--- a/self_drive.py
+++ b/self_drive.py
@@ -1,0 +1,49 @@
+#!/home/pi/.pyenv/versions/rospy3/bin/python
+import rospy
+from geometry_msgs.msg import Twist
+from sensor_msgs.msg import LaserScan
+
+
+class SelfDrive:
+    def __init__(self, publisher):
+        self.publisher = publisher
+        self.count = 0
+
+    def lds_callback(self, scan):
+        right_range, left_range = 0, 0
+        turtle_vel = Twist()
+        for i in range(40):
+            range_per_angle = scan.ranges[i]
+            right_range += range_per_angle
+            range_per_angle = scan.ranges[320+i]
+            left_range += range_per_angle
+        right_range = right_range / 40
+        left_range = left_range / 40
+        if right_range < 0.25 or left_range < 0.25:
+            if right_range < left_range:
+                turtle_vel.linear.x = 0.0
+                turtle_vel.angular.z = -1.2
+            else:
+                turtle_vel.linear.x = 0.0
+                turtle_vel.angular.z = 1.2
+        else:
+            if scan.ranges[270] > 0.25 or scan.ranges[280] > 0.25:
+                if scan.ranges[90] < 0.25 or scan.ranges[100] < 0.25:
+                    turtle_vel.linear.x = 0.18
+                    turtle_vel.angular.z = 0.0
+                else: 
+                    turtle_vel.linear.x = 0.15
+                    turtle_vel.angular.z = 1.2
+        self.publisher.publish(turtle_vel)
+
+
+def main():
+    rospy.init_node('self_drive')
+    publisher = rospy.Publisher('cmd_vel', Twist, queue_size=1)
+    driver = SelfDrive(publisher)
+    subscriber = rospy.Subscriber('scan', LaserScan, lambda scan: driver.lds_callback(scan))
+    rospy.spin()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
###벽을 인식후 띠라가는 코드 추가
- 추가 : 기존코드에서 로봇의 옆면과 뒷면의 라이더값을 통해 벽인식 후 회전하도록 함. 
 1. 내부 :   80, 90도의 라이더 값을 통해 왼쪽에 벽을 인식함.  80, 90도에 25cm이내에 벽이 존재하고 앞면에 장애물이 없을 시 직진하도록 설정함.  그 후 벽이 존재하지 않으면 시계방향으로 이동하며 회전시켜 벽으로 가도록 함.  
 2. 외부(예상) :  270, 280도의 라이더 값을 통해 오른쪽 벽을 인식함. 이때 각에서 25cm이내에 벽이 존재하고 앞면에 장애물이 없을 시 직진하도록 설정함. 그 후 옆면의 벽이 존재하지 않고 290도에 벽이 감지 될 경우 시계방향으로 회전시켜 외부 벽을 돌도록 함. 
 3. 결과: 내부벽에 부딪히지 않고 경로를 따라감.
하지만 외부벽의 경우 외부벽을 따라가다 벽을 벗어나면  반시계로 회전해 벽을 따라가지 않고 시계방향으로 회전해 경로를 벗어남.